### PR TITLE
Implement basic audio track playback

### DIFF
--- a/muslo/AudioPlayer.swift
+++ b/muslo/AudioPlayer.swift
@@ -1,0 +1,19 @@
+import Foundation
+import AVFoundation
+
+final class AudioPlayer: ObservableObject {
+    private var player: AVAudioPlayer?
+
+    func play(url: URL) {
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+            player?.play()
+        } catch {
+            print("Failed to play audio: \(error)")
+        }
+    }
+
+    func stop() {
+        player?.stop()
+    }
+}

--- a/muslo/ContentView.swift
+++ b/muslo/ContentView.swift
@@ -1,21 +1,45 @@
-//
-//  ContentView.swift
-//  muslo
-//
-//  Created by Павел Соколов on 24.06.2025.
-//
-
 import SwiftUI
+import UniformTypeIdentifiers
+import AVFoundation
 
 struct ContentView: View {
+    @State private var tracks: [Track] = []
+    @State private var isImporterPresented = false
+    @StateObject private var player = AudioPlayer()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            List {
+                ForEach(tracks) { track in
+                    HStack {
+                        Text(track.name)
+                        Spacer()
+                        Button(action: {
+                            player.play(url: track.url)
+                        }) {
+                            Image(systemName: "play.circle")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Tracks")
+            .toolbar {
+                Button(action: { isImporterPresented = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+            .fileImporter(
+                isPresented: $isImporterPresented,
+                allowedContentTypes: [.audio]
+            ) { result in
+                switch result {
+                case .success(let url):
+                    tracks.append(Track(url: url))
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
         }
-        .padding()
     }
 }
 

--- a/muslo/Track.swift
+++ b/muslo/Track.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct Track: Identifiable {
+    let id = UUID()
+    let url: URL
+
+    var name: String {
+        url.lastPathComponent
+    }
+}


### PR DESCRIPTION
## Summary
- add simple data model for tracks
- implement AVFoundation-based audio player
- allow selecting audio files from storage and play them

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685ae29e9bf88329a89c8f80b823260d