### PR TITLE
Fix audio playback permission error

### DIFF
--- a/muslo/AudioPlayer.swift
+++ b/muslo/AudioPlayer.swift
@@ -5,6 +5,13 @@ final class AudioPlayer: ObservableObject {
     private var player: AVAudioPlayer?
 
     func play(url: URL) {
+        let needsStop = url.startAccessingSecurityScopedResource()
+        defer {
+            if needsStop {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
         do {
             player = try AVAudioPlayer(contentsOf: url)
             player?.play()


### PR DESCRIPTION
## Summary
- handle security scoped URLs in `AudioPlayer` to avoid permission errors during playback

## Testing
- `swift test` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ae4d313d88329a6fd8547f06b8f94