### PR TITLE
Show track metadata with artwork

### DIFF
--- a/muslo/ContentView.swift
+++ b/muslo/ContentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
 import AVFoundation
+import UIKit
 
 struct ContentView: View {
     @State private var tracks: [Track] = []
@@ -12,7 +13,24 @@ struct ContentView: View {
             List {
                 ForEach(tracks) { track in
                     HStack {
-                        Text(track.name)
+                        if let artwork = track.artwork {
+                            Image(uiImage: artwork)
+                                .resizable()
+                                .frame(width: 50, height: 50)
+                                .cornerRadius(4)
+                        } else {
+                            Image(systemName: "music.note")
+                                .resizable()
+                                .frame(width: 50, height: 50)
+                                .foregroundColor(.secondary)
+                        }
+                        VStack(alignment: .leading) {
+                            Text(track.title)
+                                .font(.headline)
+                            Text(track.artist)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
                         Spacer()
                         Button(action: {
                             player.play(url: track.url)

--- a/muslo/Track.swift
+++ b/muslo/Track.swift
@@ -1,10 +1,44 @@
 import Foundation
+import AVFoundation
+import UIKit
 
 struct Track: Identifiable {
     let id = UUID()
     let url: URL
+    let title: String
+    let artist: String
+    let artwork: UIImage?
 
-    var name: String {
-        url.lastPathComponent
+    init(url: URL) {
+        self.url = url
+
+        let asset = AVAsset(url: url)
+
+        var foundTitle: String = url.lastPathComponent
+        var foundArtist: String = ""
+        var foundArtwork: UIImage? = nil
+
+        for metadata in asset.commonMetadata {
+            switch metadata.commonKey {
+            case .commonKeyTitle?:
+                if let value = metadata.stringValue {
+                    foundTitle = value
+                }
+            case .commonKeyArtist?:
+                if let value = metadata.stringValue {
+                    foundArtist = value
+                }
+            case .commonKeyArtwork?:
+                if let data = metadata.dataValue, let image = UIImage(data: data) {
+                    foundArtwork = image
+                }
+            default:
+                break
+            }
+        }
+
+        self.title = foundTitle
+        self.artist = foundArtist
+        self.artwork = foundArtwork
     }
 }


### PR DESCRIPTION
## Summary
- add metadata extraction in `Track` to read title, artist, and artwork
- display artwork, title, and artist in track list

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685ae63b80308329b1ada74f7a7003f7