### PR TITLE
Implement basic audio track playback

### DIFF
--- a/muslo/AudioPlayer.swift
+++ b/muslo/AudioPlayer.swift
@@ -1,0 +1,19 @@
+import Foundation
+import AVFoundation
+
+final class AudioPlayer: ObservableObject {
+    private var player: AVAudioPlayer?
+
+    func play(url: URL) {
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+            player?.play()
+        } catch {
+            print("Failed to play audio: \(error)")
+        }
+    }
+
+    func stop() {
+        player?.stop()
+    }
+}

--- a/muslo/ContentView.swift
+++ b/muslo/ContentView.swift
@@ -1,21 +1,56 @@
-//
-//  ContentView.swift
-//  muslo
-//
-//  Created by Павел Соколов on 24.06.2025.
-//
-
 import SwiftUI
+import UniformTypeIdentifiers
+import AVFoundation
 
 struct ContentView: View {
+    @State private var tracks: [Track] = []
+    @State private var isImporterPresented = false
+    @StateObject private var player = AudioPlayer()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            List {
+                ForEach(tracks) { track in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(track.name)
+                            if let artist = track.artist {
+                                Text(artist)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        Button(action: {
+                            player.play(url: track.url)
+                        }) {
+                            Image(systemName: "play.circle")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Tracks")
+            .toolbar {
+                Button(action: { isImporterPresented = true }) {
+                    Image(systemName: "plus")
+                }
+            }
+            .fileImporter(
+                isPresented: $isImporterPresented,
+                allowedContentTypes: [.audio]
+            ) { result in
+                switch result {
+                case .success(let url):
+                    Task {
+                        var track = Track(url: url)
+                        await track.loadMetadata()
+                        tracks.append(track)
+                    }
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
         }
-        .padding()
     }
 }
 

--- a/muslo/Track.swift
+++ b/muslo/Track.swift
@@ -1,0 +1,42 @@
+import Foundation
+import AVFoundation
+
+struct Track: Identifiable {
+    let id = UUID()
+    let url: URL
+
+    var title: String?
+    var artist: String?
+    var artworkData: Data?
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    mutating func loadMetadata() async {
+        let asset = AVURLAsset(url: url)
+
+        do {
+            let items = try await asset.load(.commonMetadata)
+            for item in items {
+                guard let key = item.commonKey else { continue }
+                switch key {
+                case .commonKeyTitle:
+                    title = try await item.load(.stringValue)
+                case .commonKeyArtist:
+                    artist = try await item.load(.stringValue)
+                case .commonKeyArtwork:
+                    artworkData = try await item.load(.dataValue)
+                default:
+                    break
+                }
+            }
+        } catch {
+            print("Failed to load metadata: \(error)")
+        }
+    }
+
+    var name: String {
+        title ?? url.lastPathComponent
+    }
+}


### PR DESCRIPTION
## Summary
- add asynchronous metadata loading for tracks via AVFoundation
- display artist info in the track list if available
- load metadata when importing audio files

## Testing
- `swift --version`
- `swiftc muslo/Track.swift -emit-library -o /tmp/libTrack.so` *(fails: no such module 'AVFoundation')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685ae29e9bf88329a89c8f80b823260d