### PR TITLE
Display track metadata

### DIFF
--- a/muslo/ContentView.swift
+++ b/muslo/ContentView.swift
@@ -11,9 +11,33 @@ struct ContentView: View {
         NavigationStack {
             List {
                 ForEach(tracks) { track in
-                    HStack {
-                        Text(track.name)
+                    HStack(alignment: .center, spacing: 8) {
+                        if let artwork = track.artwork {
+                            Image(uiImage: artwork)
+                                .resizable()
+                                .frame(width: 50, height: 50)
+                                .aspectRatio(contentMode: .fill)
+                                .clipped()
+                                .cornerRadius(4)
+                        } else {
+                            Image(systemName: "music.note")
+                                .resizable()
+                                .frame(width: 50, height: 50)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        VStack(alignment: .leading) {
+                            Text(track.title)
+                                .font(.headline)
+                            if let artist = track.artist {
+                                Text(artist)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
                         Spacer()
+
                         Button(action: {
                             player.play(url: track.url)
                         }) {

--- a/muslo/ContentView.swift
+++ b/muslo/ContentView.swift
@@ -58,7 +58,10 @@ struct ContentView: View {
             ) { result in
                 switch result {
                 case .success(let url):
-                    tracks.append(Track(url: url))
+                    Task {
+                        let track = await Track(url: url)
+                        tracks.append(track)
+                    }
                 case .failure(let error):
                     print(error.localizedDescription)
                 }

--- a/muslo/Track.swift
+++ b/muslo/Track.swift
@@ -12,31 +12,33 @@ struct Track: Identifiable {
 
     var name: String { title }
 
-    init(url: URL) {
+    init(url: URL) async {
         self.url = url
 
-        let asset = AVAsset(url: url)
+        let asset = AVURLAsset(url: url)
 
         var title = url.deletingPathExtension().lastPathComponent
         var artist: String?
         var album: String?
         var artwork: UIImage?
 
-        for item in asset.commonMetadata {
-            guard let key = item.commonKey?.rawValue else { continue }
-            switch key {
-            case "title":
-                title = item.stringValue ?? title
-            case "artist":
-                artist = item.stringValue
-            case "albumName":
-                album = item.stringValue
-            case "artwork":
-                if let data = item.dataValue {
-                    artwork = UIImage(data: data)
+        if let metadata = try? await asset.load(.commonMetadata) {
+            for item in metadata {
+                guard let key = item.commonKey?.rawValue else { continue }
+                switch key {
+                case "title":
+                    title = (try? await item.load(.stringValue)) ?? title
+                case "artist":
+                    artist = try? await item.load(.stringValue)
+                case "albumName":
+                    album = try? await item.load(.stringValue)
+                case "artwork":
+                    if let data = try? await item.load(.dataValue) {
+                        artwork = UIImage(data: data)
+                    }
+                default:
+                    break
                 }
-            default:
-                break
             }
         }
 

--- a/muslo/Track.swift
+++ b/muslo/Track.swift
@@ -1,10 +1,48 @@
 import Foundation
+import AVFoundation
+import UIKit
 
 struct Track: Identifiable {
     let id = UUID()
     let url: URL
+    let title: String
+    let artist: String?
+    let album: String?
+    let artwork: UIImage?
 
-    var name: String {
-        url.lastPathComponent
+    var name: String { title }
+
+    init(url: URL) {
+        self.url = url
+
+        let asset = AVAsset(url: url)
+
+        var title = url.deletingPathExtension().lastPathComponent
+        var artist: String?
+        var album: String?
+        var artwork: UIImage?
+
+        for item in asset.commonMetadata {
+            guard let key = item.commonKey?.rawValue else { continue }
+            switch key {
+            case "title":
+                title = item.stringValue ?? title
+            case "artist":
+                artist = item.stringValue
+            case "albumName":
+                album = item.stringValue
+            case "artwork":
+                if let data = item.dataValue {
+                    artwork = UIImage(data: data)
+                }
+            default:
+                break
+            }
+        }
+
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.artwork = artwork
     }
 }


### PR DESCRIPTION
## Summary
- extract title, artist, album and artwork from audio files
- show track artwork, title and artist in the list

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_685aebe64aa08329a6440779a68c435d