### PR TITLE
Add detailed playback view

### DIFF
--- a/muslo/AudioPlayer.swift
+++ b/muslo/AudioPlayer.swift
@@ -4,6 +4,11 @@ import AVFoundation
 
 final class AudioPlayer: ObservableObject {
     private var player: AVAudioPlayer?
+    private var timer: Timer?
+
+    @Published var isPlaying = false
+    @Published var currentTime: TimeInterval = 0
+    @Published var duration: TimeInterval = 0
 
     func play(url: URL) {
         // Открываем доступ к security-scoped URL
@@ -16,10 +21,45 @@ final class AudioPlayer: ObservableObject {
 
         do {
             player = try AVAudioPlayer(contentsOf: url)
+            duration = player?.duration ?? 0
+            currentTime = 0
             player?.prepareToPlay()
             player?.play()
+            isPlaying = true
+            startTimer()
         } catch {
             print("AudioPlayer error:", error.localizedDescription)
         }
+    }
+
+    func togglePlayPause() {
+        guard let player else { return }
+        if player.isPlaying {
+            player.pause()
+            stopTimer()
+            isPlaying = false
+        } else {
+            player.play()
+            startTimer()
+            isPlaying = true
+        }
+    }
+
+    func seek(to time: TimeInterval) {
+        player?.currentTime = time
+        currentTime = time
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            guard let self, let player else { return }
+            self.currentTime = player.currentTime
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
     }
 }

--- a/muslo/ContentView.swift
+++ b/muslo/ContentView.swift
@@ -6,10 +6,12 @@ struct ContentView: View {
     @State private var tracks: [Track] = []
     @StateObject private var audioPlayer = AudioPlayer()
     @State private var showingImporter = false
+    @State private var selectedIndex: Int? = nil
+    @State private var isShowingDetail = false
 
     var body: some View {
         NavigationView {
-            List(tracks) { track in
+            List(Array(tracks.enumerated()), id: \.element.id) { index, track in
                 HStack {
                     if let image = track.artwork {
                         Image(uiImage: image)
@@ -33,7 +35,8 @@ struct ContentView: View {
                     }
                 }
                 .onTapGesture {
-                    audioPlayer.play(url: track.url)
+                    selectedIndex = index
+                    isShowingDetail = true
                 }
             }
             .navigationTitle("Моя музыка")
@@ -63,6 +66,14 @@ struct ContentView: View {
                     }
                 case .failure(let error):
                     print("Importer error:", error.localizedDescription)
+                }
+            }
+            .fullScreenCover(isPresented: $isShowingDetail) {
+                if let index = selectedIndex {
+                    TrackDetailView(tracks: tracks, currentIndex: Binding(
+                        get: { selectedIndex ?? index },
+                        set: { selectedIndex = $0 }
+                    ))
                 }
             }
         }

--- a/muslo/TrackDetailView.swift
+++ b/muslo/TrackDetailView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct TrackDetailView: View {
+    let tracks: [Track]
+    @Binding var currentIndex: Int
+    @EnvironmentObject private var audioPlayer: AudioPlayer
+    @Environment(\.dismiss) private var dismiss
+
+    private var track: Track { tracks[currentIndex] }
+
+    var body: some View {
+        VStack {
+            Spacer()
+            if let image = track.artwork {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 300)
+            } else {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(height: 300)
+            }
+            Spacer()
+            VStack(alignment: .leading) {
+                Text(track.title)
+                    .font(.title2)
+                    .bold()
+                if let artist = track.artist {
+                    Text(artist)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+
+            Slider(value: Binding(
+                get: { audioPlayer.currentTime },
+                set: { newValue in
+                    audioPlayer.seek(to: newValue)
+                }
+            ), in: 0...max(audioPlayer.duration, 1))
+            .padding()
+
+            HStack(spacing: 40) {
+                Button {
+                    if currentIndex > 0 {
+                        currentIndex -= 1
+                    }
+                } label: {
+                    Image(systemName: "backward.fill")
+                        .font(.largeTitle)
+                }
+                Button {
+                    audioPlayer.togglePlayPause()
+                } label: {
+                    Image(systemName: audioPlayer.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                        .font(.system(size: 64))
+                }
+                Button {
+                    if currentIndex < tracks.count - 1 {
+                        currentIndex += 1
+                    }
+                } label: {
+                    Image(systemName: "forward.fill")
+                        .font(.largeTitle)
+                }
+            }
+            .padding(.bottom)
+        }
+        .onAppear {
+            audioPlayer.play(url: track.url)
+        }
+        .onChange(of: currentIndex) { newValue in
+            audioPlayer.play(url: tracks[newValue].url)
+        }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend `AudioPlayer` with play/pause, seeking and progress updates
- create `TrackDetailView` with album cover and playback controls
- show `TrackDetailView` when a track is tapped

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685af53970f08329928d1224cd05a56f