### PR TITLE
Add Apple Music style player screen

### DIFF
--- a/muslo/AudioPlayer.swift
+++ b/muslo/AudioPlayer.swift
@@ -4,6 +4,11 @@ import AVFoundation
 
 final class AudioPlayer: ObservableObject {
     private var player: AVAudioPlayer?
+    private var timer: Timer?
+
+    @Published var isPlaying = false
+    @Published var currentTime: TimeInterval = 0
+    @Published var duration: TimeInterval = 0
 
     func play(url: URL) {
         // Открываем доступ к security-scoped URL
@@ -16,10 +21,43 @@ final class AudioPlayer: ObservableObject {
 
         do {
             player = try AVAudioPlayer(contentsOf: url)
+            duration = player?.duration ?? 0
             player?.prepareToPlay()
             player?.play()
+            isPlaying = true
+            startTimer()
         } catch {
             print("AudioPlayer error:", error.localizedDescription)
         }
+    }
+
+    func togglePlayPause() {
+        guard let player = player else { return }
+        if player.isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            player.play()
+            isPlaying = true
+        }
+    }
+
+    func seek(to time: TimeInterval) {
+        player?.currentTime = time
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            guard let self = self, let player = self.player else { return }
+            DispatchQueue.main.async {
+                self.currentTime = player.currentTime
+                self.isPlaying = player.isPlaying
+            }
+        }
+    }
+
+    deinit {
+        timer?.invalidate()
     }
 }

--- a/muslo/ContentView.swift
+++ b/muslo/ContentView.swift
@@ -6,10 +6,13 @@ struct ContentView: View {
     @State private var tracks: [Track] = []
     @StateObject private var audioPlayer = AudioPlayer()
     @State private var showingImporter = false
+    @State private var showingPlayer = false
+    @State private var selectedIndex: Int = 0
 
     var body: some View {
         NavigationView {
-            List(tracks) { track in
+            List(tracks.indices, id: \.self) { index in
+                let track = tracks[index]
                 HStack {
                     if let image = track.artwork {
                         Image(uiImage: image)
@@ -33,7 +36,9 @@ struct ContentView: View {
                     }
                 }
                 .onTapGesture {
+                    selectedIndex = index
                     audioPlayer.play(url: track.url)
+                    showingPlayer = true
                 }
             }
             .navigationTitle("Моя музыка")
@@ -65,6 +70,10 @@ struct ContentView: View {
                     print("Importer error:", error.localizedDescription)
                 }
             }
+        }
+        .fullScreenCover(isPresented: $showingPlayer) {
+            PlayerView(tracks: $tracks, index: $selectedIndex)
+                .environmentObject(audioPlayer)
         }
         .environmentObject(audioPlayer)
     }

--- a/muslo/PlayerView.swift
+++ b/muslo/PlayerView.swift
@@ -9,69 +9,69 @@ struct PlayerView: View {
     private var track: Track { tracks[index] }
 
     var body: some View {
-        ZStack {
-            Color.black.ignoresSafeArea()
-            VStack {
-                Spacer()
-                if let artwork = track.artwork {
-                    Image(uiImage: artwork)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(maxHeight: 300)
-                        .cornerRadius(8)
-                } else {
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.3))
-                        .frame(width: 300, height: 300)
-                        .cornerRadius(8)
-                }
-                Spacer()
-                VStack(alignment: .leading) {
-                    Text(track.title)
-                        .font(.title2.bold())
-                        .foregroundColor(.white)
-                    if let artist = track.artist {
-                        Text(artist)
-                            .foregroundColor(.white.opacity(0.7))
+        GeometryReader { geo in
+            ZStack {
+                Color.black.ignoresSafeArea()
+                VStack(spacing: 0) {
+                    if let artwork = track.artwork {
+                        Image(uiImage: artwork)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: geo.size.width, height: geo.size.width)
+                            .clipped()
+                    } else {
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.3))
+                            .frame(width: geo.size.width, height: geo.size.width)
                     }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal)
-                ProgressBar(
-                    currentTime: Binding(
-                        get: { audioPlayer.currentTime },
-                        set: { audioPlayer.currentTime = $0 }
-                    ),
-                    duration: audioPlayer.duration,
-                    seek: { audioPlayer.seek(to: $0) }
-                )
-                .padding(.horizontal)
-                HStack {
-                    Text(formatTime(audioPlayer.currentTime))
                     Spacer()
-                    Text(formatTime(audioPlayer.duration))
+                    VStack(alignment: .leading) {
+                        Text(track.title)
+                            .font(.title2.bold())
+                            .foregroundColor(.white)
+                        if let artist = track.artist {
+                            Text(artist)
+                                .foregroundColor(.white.opacity(0.7))
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    ProgressBar(
+                        currentTime: Binding(
+                            get: { audioPlayer.currentTime },
+                            set: { audioPlayer.currentTime = $0 }
+                        ),
+                        duration: audioPlayer.duration,
+                        seek: { audioPlayer.seek(to: $0) }
+                    )
+                    .padding(.horizontal)
+                    HStack {
+                        Text(formatTime(audioPlayer.currentTime))
+                        Spacer()
+                        Text(formatTime(audioPlayer.duration))
+                    }
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.7))
+                    .padding(.horizontal)
+                    HStack(spacing: 40) {
+                        Button(action: previous) {
+                            Image(systemName: "backward.fill")
+                                .font(.largeTitle)
+                                .foregroundColor(.white)
+                        }
+                        Button(action: { audioPlayer.togglePlayPause() }) {
+                            Image(systemName: audioPlayer.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                                .font(.system(size: 60))
+                                .foregroundColor(.white)
+                        }
+                        Button(action: next) {
+                            Image(systemName: "forward.fill")
+                                .font(.largeTitle)
+                                .foregroundColor(.white)
+                        }
+                    }
+                    .padding(.vertical)
                 }
-                .font(.caption)
-                .foregroundColor(.white.opacity(0.7))
-                .padding(.horizontal)
-                HStack(spacing: 40) {
-                    Button(action: previous) {
-                        Image(systemName: "backward.fill")
-                            .font(.largeTitle)
-                            .foregroundColor(.white)
-                    }
-                    Button(action: { audioPlayer.togglePlayPause() }) {
-                        Image(systemName: audioPlayer.isPlaying ? "pause.circle.fill" : "play.circle.fill")
-                            .font(.system(size: 60))
-                            .foregroundColor(.white)
-                    }
-                    Button(action: next) {
-                        Image(systemName: "forward.fill")
-                            .font(.largeTitle)
-                            .foregroundColor(.white)
-                    }
-                }
-                .padding(.vertical)
             }
         }
         .onAppear {

--- a/muslo/PlayerView.swift
+++ b/muslo/PlayerView.swift
@@ -12,20 +12,21 @@ struct PlayerView: View {
         GeometryReader { geo in
             ZStack {
                 Color.black.ignoresSafeArea()
-                VStack(spacing: 0) {
+                VStack(spacing: 12) {
                     if let artwork = track.artwork {
                         Image(uiImage: artwork)
                             .resizable()
                             .scaledToFill()
                             .frame(width: geo.size.width, height: geo.size.width)
                             .clipped()
+                            .ignoresSafeArea(.container, edges: .top)
                     } else {
                         Rectangle()
                             .fill(Color.gray.opacity(0.3))
                             .frame(width: geo.size.width, height: geo.size.width)
+                            .ignoresSafeArea(.container, edges: .top)
                     }
-                    Spacer()
-                    VStack(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: 4) {
                         Text(track.title)
                             .font(.title2.bold())
                             .foregroundColor(.white)
@@ -36,6 +37,7 @@ struct PlayerView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal)
+                    .padding(.top, 4)
                     ProgressBar(
                         currentTime: Binding(
                             get: { audioPlayer.currentTime },

--- a/muslo/PlayerView.swift
+++ b/muslo/PlayerView.swift
@@ -19,12 +19,10 @@ struct PlayerView: View {
                             .scaledToFill()
                             .frame(width: geo.size.width, height: geo.size.width)
                             .clipped()
-                            .ignoresSafeArea(.container, edges: .top)
                     } else {
                         Rectangle()
                             .fill(Color.gray.opacity(0.3))
                             .frame(width: geo.size.width, height: geo.size.width)
-                            .ignoresSafeArea(.container, edges: .top)
                     }
                     VStack(alignment: .leading, spacing: 4) {
                         Text(track.title)
@@ -74,6 +72,7 @@ struct PlayerView: View {
                     }
                     .padding(.vertical)
                 }
+                .ignoresSafeArea(.container, edges: .top)
             }
         }
         .onAppear {

--- a/muslo/PlayerView.swift
+++ b/muslo/PlayerView.swift
@@ -37,20 +37,22 @@ struct PlayerView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.horizontal)
+                ProgressBar(
+                    currentTime: Binding(
+                        get: { audioPlayer.currentTime },
+                        set: { audioPlayer.currentTime = $0 }
+                    ),
+                    duration: audioPlayer.duration,
+                    seek: { audioPlayer.seek(to: $0) }
+                )
+                .padding(.horizontal)
                 HStack {
                     Text(formatTime(audioPlayer.currentTime))
-                        .foregroundColor(.white.opacity(0.7))
-                    ProgressBar(
-                        currentTime: Binding(
-                            get: { audioPlayer.currentTime },
-                            set: { audioPlayer.currentTime = $0 }
-                        ),
-                        duration: audioPlayer.duration,
-                        seek: { audioPlayer.seek(to: $0) }
-                    )
+                    Spacer()
                     Text(formatTime(audioPlayer.duration))
-                        .foregroundColor(.white.opacity(0.7))
                 }
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.7))
                 .padding(.horizontal)
                 HStack(spacing: 40) {
                     Button(action: previous) {

--- a/muslo/PlayerView.swift
+++ b/muslo/PlayerView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+struct PlayerView: View {
+    @EnvironmentObject var audioPlayer: AudioPlayer
+    @Binding var tracks: [Track]
+    @Binding var index: Int
+    @Environment(\.dismiss) private var dismiss
+
+    private var track: Track { tracks[index] }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            VStack {
+                Spacer()
+                if let artwork = track.artwork {
+                    Image(uiImage: artwork)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxHeight: 300)
+                        .cornerRadius(8)
+                } else {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.3))
+                        .frame(width: 300, height: 300)
+                        .cornerRadius(8)
+                }
+                Spacer()
+                VStack(alignment: .leading) {
+                    Text(track.title)
+                        .font(.title2.bold())
+                        .foregroundColor(.white)
+                    if let artist = track.artist {
+                        Text(artist)
+                            .foregroundColor(.white.opacity(0.7))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal)
+                HStack {
+                    Text(formatTime(audioPlayer.currentTime))
+                        .foregroundColor(.white.opacity(0.7))
+                    Slider(value: Binding(
+                        get: { audioPlayer.currentTime },
+                        set: { newVal in
+                            audioPlayer.currentTime = newVal
+                            audioPlayer.seek(to: newVal)
+                        }
+                    ), in: 0...max(audioPlayer.duration, 0.1))
+                    Text(formatTime(audioPlayer.duration))
+                        .foregroundColor(.white.opacity(0.7))
+                }
+                .padding(.horizontal)
+                HStack(spacing: 40) {
+                    Button(action: previous) {
+                        Image(systemName: "backward.fill")
+                            .font(.largeTitle)
+                            .foregroundColor(.white)
+                    }
+                    Button(action: { audioPlayer.togglePlayPause() }) {
+                        Image(systemName: audioPlayer.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                            .font(.system(size: 60))
+                            .foregroundColor(.white)
+                    }
+                    Button(action: next) {
+                        Image(systemName: "forward.fill")
+                            .font(.largeTitle)
+                            .foregroundColor(.white)
+                    }
+                }
+                .padding(.vertical)
+            }
+        }
+        .onAppear {
+            audioPlayer.play(url: track.url)
+        }
+        .onChange(of: index) { _ in
+            audioPlayer.play(url: track.url)
+        }
+        .onTapGesture(count: 2) {
+            dismiss()
+        }
+    }
+
+    private func next() {
+        guard index + 1 < tracks.count else { return }
+        index += 1
+    }
+
+    private func previous() {
+        guard index > 0 else { return }
+        index -= 1
+    }
+
+    private func formatTime(_ time: TimeInterval) -> String {
+        let minutes = Int(time) / 60
+        let seconds = Int(time) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+#Preview {
+    PlayerView(tracks: .constant([]), index: .constant(0))
+        .environmentObject(AudioPlayer())
+}

--- a/muslo/PlayerView.swift
+++ b/muslo/PlayerView.swift
@@ -40,13 +40,14 @@ struct PlayerView: View {
                 HStack {
                     Text(formatTime(audioPlayer.currentTime))
                         .foregroundColor(.white.opacity(0.7))
-                    Slider(value: Binding(
-                        get: { audioPlayer.currentTime },
-                        set: { newVal in
-                            audioPlayer.currentTime = newVal
-                            audioPlayer.seek(to: newVal)
-                        }
-                    ), in: 0...max(audioPlayer.duration, 0.1))
+                    ProgressBar(
+                        currentTime: Binding(
+                            get: { audioPlayer.currentTime },
+                            set: { audioPlayer.currentTime = $0 }
+                        ),
+                        duration: audioPlayer.duration,
+                        seek: { audioPlayer.seek(to: $0) }
+                    )
                     Text(formatTime(audioPlayer.duration))
                         .foregroundColor(.white.opacity(0.7))
                 }

--- a/muslo/ProgressBar.swift
+++ b/muslo/ProgressBar.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ProgressBar: View {
+    @Binding var currentTime: TimeInterval
+    let duration: TimeInterval
+    var seek: (TimeInterval) -> Void
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.3))
+                    .frame(height: 8)
+                Capsule()
+                    .fill(Color.white)
+                    .frame(width: width * CGFloat(progress), height: 8)
+            }
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let clamped = min(max(0, value.location.x), width)
+                        let newTime = TimeInterval(clamped / width) * duration
+                        currentTime = newTime
+                        seek(newTime)
+                    }
+            )
+        }
+        .frame(height: 20)
+    }
+
+    private var progress: Double {
+        guard duration > 0 else { return 0 }
+        return currentTime / duration
+    }
+}

--- a/muslo/ProgressBar.swift
+++ b/muslo/ProgressBar.swift
@@ -5,16 +5,18 @@ struct ProgressBar: View {
     let duration: TimeInterval
     var seek: (TimeInterval) -> Void
 
+    @State private var dragging = false
+
     var body: some View {
         GeometryReader { geometry in
             let width = geometry.size.width
             ZStack(alignment: .leading) {
                 Capsule()
                     .fill(Color.white.opacity(0.3))
-                    .frame(height: 8)
+                    .frame(height: barHeight)
                 Capsule()
                     .fill(Color.white)
-                    .frame(width: width * CGFloat(progress), height: 8)
+                    .frame(width: width * CGFloat(progress), height: barHeight)
                     .animation(.linear(duration: 0.4), value: progress)
             }
             .contentShape(Rectangle())
@@ -24,15 +26,22 @@ struct ProgressBar: View {
                         let clamped = min(max(0, value.location.x), width)
                         let newTime = TimeInterval(clamped / width) * duration
                         currentTime = newTime
-                        seek(newTime)
+                        if !dragging { dragging = true }
+                    }
+                    .onEnded { _ in
+                        dragging = false
+                        seek(currentTime)
                     }
             )
         }
         .frame(height: 20)
+        .animation(.easeInOut(duration: 0.2), value: dragging)
     }
 
     private var progress: Double {
         guard duration > 0 else { return 0 }
         return currentTime / duration
     }
+
+    private var barHeight: CGFloat { dragging ? 12 : 8 }
 }

--- a/muslo/ProgressBar.swift
+++ b/muslo/ProgressBar.swift
@@ -15,6 +15,7 @@ struct ProgressBar: View {
                 Capsule()
                     .fill(Color.white)
                     .frame(width: width * CGFloat(progress), height: 8)
+                    .animation(.linear(duration: 0.4), value: progress)
             }
             .contentShape(Rectangle())
             .gesture(


### PR DESCRIPTION
## Summary
- add playback controls with timer and play/pause logic
- open new `PlayerView` as a full-screen cover to show current song
- wire up tapping a song to present the new screen

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685b279d5ed483299ee80fa68a1e23df